### PR TITLE
Fix issue #20 export of contour and density plots

### DIFF
--- a/src/main/java/net/ericaro/surfaceplotter/surface/JSurface.java
+++ b/src/main/java/net/ericaro/surfaceplotter/surface/JSurface.java
@@ -595,7 +595,8 @@ public class JSurface extends javax.swing.JComponent {
 		if (data_available && !interrupted) {
 			boolean old = printing;
 			printing = true;
-			
+			printwidth = getBounds().width;
+			printheight = getBounds().height;
 			draw(g);
 			
 			


### PR DESCRIPTION
printwidth and printheight need to be set since computeArea uses them when printing == true.